### PR TITLE
Fix infinite money exploit with QuickShop

### DIFF
--- a/src/main/java/me/justeli/coins/events/DropCoin.java
+++ b/src/main/java/me/justeli/coins/events/DropCoin.java
@@ -120,7 +120,7 @@ public class DropCoin
             return;
         }
 
-        if (e.getExpToDrop() != 0)
+        if (e.getExpToDrop() > 0)
             dropBlockCoin(e.getBlock(), e.getPlayer());
     }
 


### PR DESCRIPTION
QuickShop's [build permission check ](https://github.com/Ghost-chu/QuickShop-Reremake/blob/a0aed087de9bb3d5c84cbfee863719a565d2c026/src/main/java/org/maxgamer/quickshop/Util/PermissionChecker.java#L75)method uses a block break event with the experience drop set to -1, since coins only checked for it not being equal to 0 clicking a chest results in coins dropping